### PR TITLE
parser: Adjust code format on method Parser::eatOpenParenthesis

### DIFF
--- a/libs/mcparser/src/parser.cc
+++ b/libs/mcparser/src/parser.cc
@@ -41,9 +41,7 @@ bool mcparser::Parser::eatOpenParenthesis(std::vector<mclexer::Token>* tokens) {
     auto token = this->eatNextToken(tokens);
 
     if (token.kind != mclexer::token_symbol && token.value != "(") {
-        this->errors.push_back(
-            mcparser::ParserError::openParenthesisExpected(
-                token));
+        this->errors.push_back(mcparser::ParserError::openParenthesisExpected(token));
         return false;
     }
     return true;


### PR DESCRIPTION
You don't to accept it, I'm just trying some stuff with Pierri.